### PR TITLE
feat: Upgrade mongo image and include env variable PORT in the docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: ${DB_PASS:-example}
     volumes:
       - dbdata:/data/db
+    ports:
+      - ${MONGODB_PORT:-27017}:27017
 
 volumes:
   dbdata:


### PR DESCRIPTION
Hi,

I upgraded the image mongo to stable version 4.4.10. The support to version 4.0 expires in 6 months.
The lib mongoose is compatible with version 4.4.10.

I removed the bind to port in the mongo service, because I think that is unnecessary to expose port to the external host.

I include the env variable PORT to facilite change the node service port via .env environment variable.